### PR TITLE
Update monodepth_simple

### DIFF
--- a/monodepth_simple.py
+++ b/monodepth_simple.py
@@ -52,12 +52,11 @@ def test_simple(params):
     """Test function."""
 
     left  = tf.placeholder(tf.float32, [2, args.input_height, args.input_width, 3])
-    # model = MonodepthModel(params, "test", left, None)
-    model = MonodepthModel(params, "test", left, None, None, None, None)    # Add None 
-    input_image = cv2.imread(args.image_path)                       # Change from scipy
-    input_image = cv2.cvtColor(input_image,cv2.COLOR_BGR2RGB)       # Add to convert from BGR to RGB
+    model = MonodepthModel(params, "test", left, None, None, None, None)
+    input_image = cv2.imread(args.image_path)
+    input_image = cv2.cvtColor(input_image,cv2.COLOR_BGR2RGB)
     original_height, original_width, num_channels = input_image.shape
-    input_image = cv2.resize(input_image,(int(args.input_width),int(args.input_height)))    # Changed from scipy resize
+    input_image = cv2.resize(input_image,(int(args.input_width),int(args.input_height)))
     input_image = input_image.astype(np.float32) / 255
     input_images = np.stack((input_image, np.fliplr(input_image)), 0)
 
@@ -78,14 +77,14 @@ def test_simple(params):
     restore_path = args.checkpoint_path.split(".")[0]
     train_saver.restore(sess, restore_path)
 
-    disp = sess.run(model.invDepth_left_est[0], feed_dict={left: input_images}) # Changed from old 'disp_left_est' to 'invDepth_left_est'
+    disp = sess.run(model.invDepth_left_est[0], feed_dict={left: input_images})
     disp_pp = post_process_disparity(disp.squeeze()).astype(np.float32)
 
     output_directory = os.path.dirname(args.image_path)
     output_name = os.path.splitext(os.path.basename(args.image_path))[0]
 
     np.save(os.path.join(output_directory, "{}_disp.npy".format(output_name)), disp_pp)
-    disp_to_img = cv2.resize(disp_pp.squeeze(), (original_width, original_height)) # Changed from scipy resize
+    disp_to_img = cv2.resize(disp_pp.squeeze(), (original_width, original_height))
     plt.imsave(os.path.join(output_directory, "{}_disp.png".format(output_name)), disp_to_img, cmap='jet')
 
     print('done!')

--- a/monodepth_simple.py
+++ b/monodepth_simple.py
@@ -26,6 +26,8 @@ from monodepth_model import *
 from monodepth_dataloader import *
 from average_gradients import *
 
+import cv2
+
 parser = argparse.ArgumentParser(description='Monodepth TensorFlow implementation.')
 
 parser.add_argument('--encoder',          type=str,   help='type of encoder, vgg or resnet50', default='resnet50-forward')
@@ -51,11 +53,11 @@ def test_simple(params):
 
     left  = tf.placeholder(tf.float32, [2, args.input_height, args.input_width, 3])
     # model = MonodepthModel(params, "test", left, None)
-    model = MonodepthModel(params, "test", left, None, None, None, None)
-
-    input_image = scipy.misc.imread(args.image_path, mode="RGB")
+    model = MonodepthModel(params, "test", left, None, None, None, None)    # Add None 
+    input_image = cv2.imread(args.image_path)                       # Change from scipy
+    input_image = cv2.cvtColor(input_image,cv2.COLOR_BGR2RGB)       # Add to convert from BGR to RGB
     original_height, original_width, num_channels = input_image.shape
-    input_image = scipy.misc.imresize(input_image, [args.input_height, args.input_width], interp='lanczos')
+    input_image = cv2.resize(input_image,(int(args.input_width),int(args.input_height)))    # Changed from scipy resize
     input_image = input_image.astype(np.float32) / 255
     input_images = np.stack((input_image, np.fliplr(input_image)), 0)
 
@@ -76,15 +78,15 @@ def test_simple(params):
     restore_path = args.checkpoint_path.split(".")[0]
     train_saver.restore(sess, restore_path)
 
-    disp = sess.run(model.disp_left_est[0], feed_dict={left: input_images})
+    disp = sess.run(model.invDepth_left_est[0], feed_dict={left: input_images}) # Changed from old 'disp_left_est' to 'invDepth_left_est'
     disp_pp = post_process_disparity(disp.squeeze()).astype(np.float32)
 
     output_directory = os.path.dirname(args.image_path)
     output_name = os.path.splitext(os.path.basename(args.image_path))[0]
 
     np.save(os.path.join(output_directory, "{}_disp.npy".format(output_name)), disp_pp)
-    disp_to_img = scipy.misc.imresize(disp_pp.squeeze(), [original_height, original_width])
-    plt.imsave(os.path.join(output_directory, "{}_disp.png".format(output_name)), disp_to_img, cmap='plasma')
+    disp_to_img = cv2.resize(disp_pp.squeeze(), (original_width, original_height)) # Changed from scipy resize
+    plt.imsave(os.path.join(output_directory, "{}_disp.png".format(output_name)), disp_to_img, cmap='jet')
 
     print('done!')
 

--- a/monodepth_simple.py
+++ b/monodepth_simple.py
@@ -100,10 +100,12 @@ def main(_):
         do_stereo=False,
         wrap_mode="border",
         use_deconv=False,
-        alpha_image_loss=0,
+        alpha_image_loss =0,
         disp_gradient_loss_weight=0,
-        lr_loss_weight=0,
-        full_summary=False)
+        lr_loss_weight  = 0,
+        full_summary    = False,
+        lidar_weight    = 15.0,
+        do_gradient_fix = True)
 
     test_simple(params)
 

--- a/monodepth_simple.py
+++ b/monodepth_simple.py
@@ -28,7 +28,7 @@ from average_gradients import *
 
 parser = argparse.ArgumentParser(description='Monodepth TensorFlow implementation.')
 
-parser.add_argument('--encoder',          type=str,   help='type of encoder, vgg or resnet50', default='vgg')
+parser.add_argument('--encoder',          type=str,   help='type of encoder, vgg or resnet50', default='resnet50-forward')
 parser.add_argument('--image_path',       type=str,   help='path to the image', required=True)
 parser.add_argument('--checkpoint_path',  type=str,   help='path to a specific checkpoint to load', required=True)
 parser.add_argument('--input_height',     type=int,   help='input height', default=256)

--- a/monodepth_simple.py
+++ b/monodepth_simple.py
@@ -50,7 +50,8 @@ def test_simple(params):
     """Test function."""
 
     left  = tf.placeholder(tf.float32, [2, args.input_height, args.input_width, 3])
-    model = MonodepthModel(params, "test", left, None)
+    # model = MonodepthModel(params, "test", left, None)
+    model = MonodepthModel(params, "test", left, None, None, None, None)
 
     input_image = scipy.misc.imread(args.image_path, mode="RGB")
     original_height, original_width, num_channels = input_image.shape

--- a/readme.md
+++ b/readme.md
@@ -57,6 +57,12 @@ python monodepth_main.py --mode test --data_path ~/data/KITTI/ \
 --filenames_file utils/filenames/eigen_test_files.txt --log_directory tmp/ \
 --checkpoint_path tmp/my_model/model-181250 --save_visualized
 ```
+
+## Testing on single image
+To test the network on one image you can use the `monodepth_simple.py` it should svae the output file with the same input file name+'_disp' in the same directory
+```shell
+python monodepth_simple.py --image /path-to-image --checkpoint_path /path-to-model
+```
 **Please note that there is NO extension after the checkpoint name**  
 
 This will create a file named invDepth.npy containing result. 


### PR DESCRIPTION
Here the list of all Changes:
- Changed default encoder to 'resnet50-forward'
- Fixed calling MonodepthModel function by adding 3 None parameters that were required to run properly 
- Changed all scipy image functions that aren't working to cv2 functions (imread, resize)
- Changed old 'disp_left_est' to 'invDepth_left_est'
- Updated Params list adding (lidar_weight = 15.0, do_gradient_fix = True) which have no effect on the result but required to run properly